### PR TITLE
ENG-496 Update READMEs to recommend Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ const myBtn = () => <Button>Do something</Button>;
 
 ### **Development**
 
+Recommended Node and Npm version 
+
+`Node: V18.1.0 and later`
+`Npm : V8.19.0 and later`
+
 Clone the [design-components GitHub project](https://github.com/local-civics/design-components) then start Storybook.
 
 `npm install && cd packages/hub && npm run start`


### PR DESCRIPTION
The design-components project does not currently have a valid recommended Node/NPM version. This causes confusion when attempting to setup the project for the first time as the story book is not running locally , so updated the READMEs file to have recommended Node and Npm versions